### PR TITLE
 Greenspace UX refresh: seasonal highlights, sticky header, marker halo/   dimming, breeze toggle

### DIFF
--- a/lexgreen/pages.py
+++ b/lexgreen/pages.py
@@ -133,7 +133,10 @@ def greenspace():
         }
     except Exception:
         return redirect(url_for('pages.index'))
-    return render_template('greenspace.html', name=name, bounds=bounds)
+    # Pass simple meta (description/features) when available so the page
+    # can render lightweight amenities and suggestions without new APIs.
+    gs_meta = CAMPUS_DATA.get('location_info', {}).get(name)
+    return render_template('greenspace.html', name=name, bounds=bounds, gs_meta=gs_meta)
 
 
 @pages_bp.route('/my-adoptions')
@@ -198,4 +201,3 @@ def upload_tree_photo(tree_id: int):
 @pages_bp.route('/uploads/<path:filename>')
 def uploaded_file(filename):
     return send_from_directory(current_app.config['UPLOAD_FOLDER'], filename)
-

--- a/static/js/greenspace.js
+++ b/static/js/greenspace.js
@@ -1,0 +1,354 @@
+// Lightweight enhancements for greenspace page
+// - Renders description, amenity badges, and "good for" chips
+// - Shows a small seasonal highlight based on actual trees in bounds
+(function(){
+  function onReady(fn){
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn, { once: true });
+    else fn();
+  }
+
+  const AMENITY_MAP = [
+    { key: 'water', test: /water|fountain|lily|pond/i, emoji: '🚰', label: 'Water' },
+    { key: 'bench', test: /bench/i, emoji: '🪑', label: 'Benches' },
+    { key: 'shade', test: /shade/i, emoji: '🌳', label: 'Shade' },
+    { key: 'trail', test: /trail|path|walkway/i, emoji: '🥾', label: 'Paths/Trails' },
+    { key: 'open',  test: /open grass|lawn|field/i, emoji: '🌿', label: 'Open Lawn' },
+    { key: 'garden', test: /garden|native plants|flowers/i, emoji: '🌸', label: 'Garden' },
+    { key: 'wifi', test: /wifi/i, emoji: '📶', label: 'Wi‑Fi Nearby' },
+    { key: 'food', test: /food|student center/i, emoji: '🍴', label: 'Food Nearby' },
+    { key: 'bike', test: /bike/i, emoji: '🚲', label: 'Bike Rack' },
+    { key: 'quiet', test: /quiet|less crowded/i, emoji: '🤫', label: 'Quiet Corners' },
+    { key: 'art', test: /art/i, emoji: '🖼️', label: 'Art' }
+  ];
+
+  // Friendly per-greenspace placeholders keyed by SVG id/name
+  const PLACEHOLDERS = {
+    // TODO: refine amenities/description later for Limestone_Lawn
+    Limestone_Lawn: {
+      description: 'A calm open lawn popular for quick breaks and casual meetups.',
+      features: ['Open Grass Area', 'Shade Trees', 'Benches', 'Paths'],
+      goodfor: ['Reading', 'Hang out', 'Walking']
+    },
+    // TODO: refine amenities/description later for Gatton_Bls
+    Gatton_Bls: {
+      description: 'Greens around Gatton College.',
+      features: ['Shade Trees', 'Gardens'],
+      goodfor: ['Study spot', 'Walking']
+    },
+    // TODO: refine amenities/description later for Ezra_Bldg
+    Ezra_Bldg: {
+      description: 'Pocket green near the Ezra building.',
+      features: ['Open Grass Area', 'Benches'],
+      goodfor: ['Relaxing', 'Reading']
+    },
+    // TODO: refine amenities/description later for Art_Center
+    Art_Center: {
+      description: 'Art-adjacent lawn with visual interest.',
+      features: ['Art Installations', 'Shade Trees', 'Benches'],
+      goodfor: ['Photography', 'Walking']
+    },
+    // TODO: refine amenities/description later for Art_Lib
+    Art_Lib: {
+      description: 'Green strip by the art library.',
+      features: ['Benches', 'Shade Trees', 'Paths'],
+      goodfor: ['Study spot', 'Meditation']
+    },
+    // TODO: refine amenities/description later for Patterson_OT
+    Patterson_OT: {
+      description: 'Outdoor pathway near the Student Center.',
+      features: ['Benches', 'Less Crowded', 'Paths'],
+      goodfor: ['Walking', 'Meditation']
+    },
+    // TODO: refine amenities/description later for Gatton_SC
+    Gatton_SC: {
+      description: 'Student Center seating green.',
+      features: ['Nearby Food', 'Seating', 'Bike Racks'],
+      goodfor: ['Hang out', 'Picnic']
+    },
+    // TODO: refine amenities/description later for Old_Engineer
+    Old_Engineer: {
+      description: 'Historic corridor of trees and lawn.',
+      features: ['Shade Trees', 'Paths', 'Benches'],
+      goodfor: ['Walking', 'Reading']
+    },
+    // TODO: refine amenities/description later for President
+    President: {
+      description: 'Serene garden near the President’s area.',
+      features: ['Lily Pond', 'Native Plants', 'Benches', 'Shade Trees'],
+      goodfor: ['Meditation', 'Photography']
+    },
+    // TODO: refine amenities/description later for Mining
+    Mining: {
+      description: 'Small lawn near the mining area.',
+      features: ['Open Grass Area', 'Shade Trees'],
+      goodfor: ['Relaxing']
+    },
+    // TODO: refine amenities/description later for Dorms
+    Dorms: {
+      description: 'Residential-side green corridor.',
+      features: ['Paths', 'Shade Trees', 'Open Grass Area'],
+      goodfor: ['Jogging', 'Walking']
+    },
+    // TODO: refine amenities/description later for Funkhouser
+    Funkhouser: {
+      description: 'Shaded path by Funkhouser.',
+      features: ['Shaded Trees', 'Study Spots', 'Benches'],
+      goodfor: ['Study spot', 'Walking']
+    },
+    // TODO: refine amenities/description later for FPAT_Alcove
+    FPAT_Alcove: {
+      description: 'FPAT-adjacent alcove with pockets of shade.',
+      features: ['Shade Trees', 'Benches'],
+      goodfor: ['Reading', 'Relaxing']
+    },
+    // TODO: refine amenities/description later for WT_Young
+    WT_Young: {
+      description: 'WT Young Library lawn — open and study-friendly.',
+      features: ['Open Grass Area', 'Study Spots', 'WiFi Access', 'Natural Shade'],
+      goodfor: ['Study spot', 'Reading', 'Hang out']
+    },
+    // TODO: refine amenities/description later for Memorial
+    Memorial: {
+      description: 'Green near the Memorial area.',
+      features: ['Paths', 'Shade Trees'],
+      goodfor: ['Walking']
+    },
+    // TODO: refine amenities/description later for White_Hall
+    White_Hall: {
+      description: 'Green spine by White Hall.',
+      features: ['Paths', 'Benches', 'Shade Trees'],
+      goodfor: ['Walking', 'Study spot']
+    }
+  };
+
+  // Derive activity chips from amenities/features
+  function deriveActivities(text){
+    const s = (text || '').toLowerCase();
+    const chips = new Set();
+    if (/trail|path|walkway/.test(s)) chips.add('Walking');
+    if (/open grass|lawn|field|shade/.test(s)) chips.add('Reading');
+    if (/open grass|lawn|field/.test(s)) chips.add('Hang out');
+    if (/bench/.test(s)) chips.add('Relaxing');
+    if (/quiet|less crowded/.test(s)) chips.add('Meditation');
+    if (/wifi|study/.test(s)) chips.add('Study spot');
+    if (/bike/.test(s)) chips.add('Cycling');
+    if (/garden|flowers|native plants/.test(s)) chips.add('Photography');
+    if (/food|student center/.test(s)) chips.add('Picnic');
+    return Array.from(chips);
+  }
+
+  function dedupe(arr){ return Array.from(new Set(arr.filter(Boolean))); }
+
+  // Seasonal species facts (tiny, client-side)
+  const SPECIES_FACTS = [
+    { key: 'ginkgo', test: /(ginkgo|gingko)/i, label: 'Ginkgo', fact: 'Fan-shaped leaves turn brilliant gold in fall.' },
+    { key: 'maple', test: /(acer|maple)/i, label: 'Maple', fact: 'Known for vivid reds and oranges in fall.' },
+    { key: 'sweetgum', test: /(liquidambar|sweet\s?gum)/i, label: 'Sweetgum', fact: 'Star-shaped leaves with rainbow fall color.' },
+    { key: 'baldcypress', test: /(taxodium|bald\s?cypress)/i, label: 'Bald cypress', fact: 'Rusty needles in late fall; a deciduous conifer.' },
+    { key: 'oak', test: /(quercus|oak)/i, label: 'Oak', fact: 'Strong structure; many species with lasting fall leaves.' },
+    { key: 'beech', test: /(fagus|beech)/i, label: 'Beech', fact: 'Coppery leaves often persist into winter.' },
+    { key: 'holly', test: /(ilex|holly)/i, label: 'Holly', fact: 'Glossy evergreen leaves; bright berries in winter.' },
+    { key: 'spruce', test: /(picea|spruce)/i, label: 'Spruce', fact: 'Evergreen spires add winter color and shelter.' },
+    { key: 'cedar', test: /(cedrus|juniperus|cedar|juniper)/i, label: 'Cedar/Juniper', fact: 'Fragrant evergreen foliage carries through winter.' },
+    { key: 'pine', test: /(pinus|pine)/i, label: 'Pine', fact: 'Year‑round green needles; calming scent.' }
+  ];
+
+  function speciesFactFor(tree){
+    const s = `${tree.latin_name || ''} ${tree.common_name || ''}`;
+    const f = SPECIES_FACTS.find(x => x.test.test(s));
+    return f || null;
+  }
+
+  function currentSeasonKey(month){
+    // 0-1 winter; 2-4 spring; 5-7 summer; 8-9 fall; 10-11 late_fall
+    if (month === 10 || month === 11) return 'late_fall';
+    if (month === 0 || month === 1) return 'winter';
+    if (month >= 2 && month <= 4) return 'spring';
+    if (month >= 5 && month <= 7) return 'summer';
+    return 'fall';
+  }
+
+  const SEASON_KEYS = {
+    late_fall: ['ginkgo','maple','sweetgum','baldcypress','oak','beech'],
+    winter: ['holly','spruce','cedar','pine','beech','oak'],
+    fall: ['maple','sweetgum','oak','ginkgo','baldcypress'],
+    spring: ['maple','oak','spruce','cedar','pine'],
+    summer: ['oak','spruce','cedar','pine']
+  };
+
+  function pickSeasonalCandidates(trees){
+    const m = new Date().getMonth();
+    const key = currentSeasonKey(m);
+    const allowed = new Set(SEASON_KEYS[key] || []);
+    const all = [];
+    trees.forEach(t => {
+      const f = speciesFactFor(t);
+      if (!f) return;
+      if (!allowed.size || allowed.has(f.key)) {
+        all.push({ tree: t, fact: f });
+      }
+    });
+    // random sample up to 4
+    for (let i = all.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [all[i], all[j]] = [all[j], all[i]];
+    }
+    return all.slice(0, Math.min(4, all.length));
+  }
+
+  let rotateTimer = null;
+  function showSeasonal(items, index){
+    const wrap = document.getElementById('gs-seasonal');
+    const imgWrap = wrap ? wrap.querySelector('.s-img img') : null;
+    const titleEl = document.getElementById('gs-season-title');
+    const textEl = document.getElementById('gs-season-text');
+    if (!wrap || !titleEl || !textEl) return;
+    if (!items || !items.length) {
+      // fallback generic
+      titleEl.textContent = 'Seasonal highlight';
+      textEl.textContent = 'Explore trees in this space — more highlights coming soon.';
+      wrap.hidden = false;
+      return;
+    }
+    const it = items[index % items.length];
+    const t = it.tree;
+    const icon = (window.treeIcons && window.treeIcons.getIconUrl) ? window.treeIcons.getIconUrl(t.latin_name, t.common_name) : '';
+    if (imgWrap && icon) { imgWrap.src = icon; imgWrap.alt = `${t.common_name || it.fact.label}`; }
+    titleEl.textContent = `${it.fact.label} near you`;
+    textEl.textContent = it.fact.fact;
+    wrap.hidden = false;
+    try { wrap.classList.remove('pulse'); void wrap.offsetWidth; wrap.classList.add('pulse'); } catch(_) {}
+  }
+
+  function startRotation(items){
+    if (rotateTimer) { try { clearInterval(rotateTimer); } catch(e) {} rotateTimer = null; }
+    if (!items || !items.length) { showSeasonal(items, 0); return; }
+    let idx = 0;
+    showSeasonal(items, idx);
+    rotateTimer = setInterval(() => { idx = (idx + 1) % items.length; showSeasonal(items, idx); }, 8000);
+  }
+
+  // Expose a tiny seasonal updater called by the page after tree fetch
+  window.gsSeasonal = {
+    update(trees, name){
+      try {
+        const items = pickSeasonalCandidates(Array.isArray(trees) ? trees : []);
+        startRotation(items);
+      } catch (e) { /* ignore */ }
+    }
+  };
+
+  onReady(function(){
+    const t = document.getElementById('gs-data');
+    if (!t) return;
+    const metaRaw = t.dataset.meta || '';
+    const name = t.dataset.name || 'Greenspace';
+    let meta = null;
+    try { meta = metaRaw ? JSON.parse(metaRaw) : null; } catch(_) { meta = null; }
+    // Fallback to friendly placeholders by SVG id/name
+    if (!meta && PLACEHOLDERS[name]) meta = PLACEHOLDERS[name];
+    if (!meta) {
+      const pretty = String(name || 'this greenspace').replace(/_/g, ' ');
+      // TODO: refine generic fallback copy later
+      meta = {
+        description: `A campus greenspace: ${pretty}.`,
+        features: ['Open Grass Area', 'Shade Trees', 'Paths'],
+        goodfor: ['Walking', 'Reading', 'Hang out']
+      };
+    }
+
+    const descEl = document.getElementById('gs-desc') || document.getElementById('gs-desc-header');
+    const amEl = document.getElementById('gs-amenities');
+    const gfEl = document.getElementById('gs-goodfor');
+    const sWrap = document.getElementById('gs-seasonal');
+    const sTitle = document.getElementById('gs-season-title');
+    const sText = document.getElementById('gs-season-text');
+
+    const features = Array.isArray(meta?.features) ? meta.features : [];
+    const desc = (meta && meta.description) ? meta.description : `Tell a short story about ${name}.`;
+
+    // Description
+    if (descEl) descEl.textContent = desc;
+
+    // Breeze toggle (ambient gradient + very quiet rustling loop)
+    (function setupBreeze(){
+      const btn = document.getElementById('breeze-toggle');
+      const container = document.querySelector('.gs-container');
+      if (!btn || !container) return;
+      const audioUrl = (window.gsBreeze && window.gsBreeze.url) || '/static/audio/explore-rustling.mp3';
+      let a = null; let on = false;
+      function ensure(){ if (!a) { try { a = new Audio(audioUrl); a.loop = true; a.volume = 0.05; } catch(_) { a = null; } } }
+      function toggle(){
+        on = !on;
+        btn.setAttribute('aria-pressed', String(on));
+        container.classList.toggle('breeze', on);
+        if (navigator.vibrate) { try { navigator.vibrate(on ? 6 : 3); } catch(_) {} }
+        try {
+          ensure();
+          if (a) {
+            if (on) { a.currentTime = 0; a.play().catch(()=>{}); }
+            else { a.pause(); }
+          }
+        } catch(_) {}
+      }
+      btn.addEventListener('click', toggle);
+      document.addEventListener('visibilitychange', () => { try { if (document.hidden && a) a.pause(); } catch(_) {} });
+    })();
+
+    // Soft haptic when interacting with seasonal banner
+    (function setupSeasonalHaptics(){
+      const card = document.getElementById('gs-season-card');
+      if (!card) return;
+      card.addEventListener('click', () => { try { if (navigator.vibrate) navigator.vibrate(8); } catch(_) {} });
+    })();
+
+    // Amenities
+    const amenityTokens = [];
+    if (features.length) {
+      features.forEach(f => {
+        const found = AMENITY_MAP.find(a => a.test.test(String(f)));
+        if (found) amenityTokens.push(found.key);
+      });
+    }
+    // Also try description text to infer amenities
+    AMENITY_MAP.forEach(a => { if (a.test.test(desc)) amenityTokens.push(a.key); });
+    const finalAm = dedupe(amenityTokens).map(k => AMENITY_MAP.find(a => a.key === k));
+
+    if (amEl) {
+      amEl.innerHTML = '';
+      if (!finalAm.length) {
+        amEl.innerHTML = '<span style="opacity:.8">No amenities recorded yet.</span>';
+      } else {
+        finalAm.forEach(a => {
+          const el = document.createElement('span');
+          el.className = 'amenity';
+          el.innerHTML = `<span class="a-emoji" aria-hidden="true">${a.emoji}</span><span>${a.label}</span>`;
+          el.title = a.label;
+          amEl.appendChild(el);
+        });
+      }
+    }
+
+    // Activities
+    const activityList = dedupe([
+      ...(Array.isArray(meta?.goodfor) ? meta.goodfor : []),
+      ...deriveActivities(features.join(' | ')),
+      ...deriveActivities(desc)
+    ]);
+    if (gfEl) {
+      gfEl.innerHTML = '';
+      if (!activityList.length) {
+        gfEl.innerHTML = '<span style="opacity:.8">We will add suggestions here.</span>';
+      } else {
+        activityList.forEach(lbl => {
+          const chip = document.createElement('span');
+          chip.className = 'chip';
+          chip.textContent = lbl;
+          gfEl.appendChild(chip);
+        });
+      }
+    }
+
+    // Seasonal highlight is populated after trees are fetched via window.gsSeasonal.update
+  });
+})();

--- a/templates/greenspace.html
+++ b/templates/greenspace.html
@@ -4,11 +4,23 @@
 
 {% block extra_css %}
 <style>
-  .gs-container { padding: 18px; }
-  .gs-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+  .gs-container { padding: 18px; position: relative; }
+  .gs-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; position: sticky; top: 0; z-index: 5; background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 10px 14px; box-shadow: 0 6px 14px rgba(0,0,0,0.14); }
+  .gs-header > div:first-child { display:flex; flex-direction: column; gap: 2px; }
+  .gs-header small { color: var(--muted); }
   .gs-actions a { margin-right: 10px; }
   .card { background: var(--surface); border-radius: 16px; padding: 14px; border: 1px solid var(--border); box-shadow: 0 6px 14px rgba(0,0,0,0.18); color: var(--text); }
   #gs-map { height: calc(60vh); border-radius: 12px; overflow: hidden; box-shadow: 0 8px 20px rgba(0,0,0,0.25); }
+  /* Map focus breathing frame */
+  .map-focus { position: relative; }
+  .map-focus::after { content: ''; position: absolute; inset: -2px; border-radius: 14px; pointer-events: none; box-shadow: 0 0 0 2px rgba(85,139,110,.18), 0 0 18px rgba(85,139,110,.08); animation: focusBreath 4.6s ease-in-out infinite; }
+  @keyframes focusBreath {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(85,139,110,.18), 0 0 18px rgba(85,139,110,.08); }
+    50%      { box-shadow: 0 0 0 2px rgba(85,139,110,.34), 0 0 26px rgba(85,139,110,.16); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .map-focus::after { animation: none; }
+  }
   .tree-list { margin-top: 12px; }
   .list-head { display:flex; align-items:center; gap:8px; color: var(--text-strong); }
   .list { margin-top: 10px; display:flex; flex-direction: column; gap:8px; }
@@ -22,7 +34,61 @@
   .ti-arrow { color: var(--muted); }
 
   /* CTA and secondary link styles are centralized in static/css/main.css */
-
+  /* Greenspace meta UI */
+  .gs-meta { display:grid; gap:12px; grid-template-columns: 1fr; }
+  .gs-desc { color: var(--text); line-height: 1.4; }
+  .gs-section-title { margin: 0; font-weight: 650; color: var(--text-strong); font-size: 0.95rem; }
+  .amenities, .goodfor { display:flex; flex-wrap: wrap; gap:8px; margin-top:6px; }
+  .amenity, .chip { display:inline-flex; align-items:center; gap:6px; padding:6px 9px; border-radius:999px; background: var(--surface-2); border:1px solid var(--border); color: var(--text); transition: transform .12s ease, background .2s ease, border-color .2s ease, box-shadow .2s ease; }
+  .amenity:hover, .chip:hover { transform: translateY(-1px); background: var(--surface); border-color: var(--border-strong); box-shadow: 0 4px 10px rgba(0,0,0,.12); }
+  .amenity .a-emoji { font-size: 1rem; line-height: 1; }
+  .seasonal { display:flex; align-items:center; gap:8px; padding:8px 10px; border-radius:12px; background: var(--surface-2); border:1px solid var(--border); color: var(--text); }
+  .seasonal strong { color: var(--text-strong); }
+  .pulse { animation: pulse .9s ease; }
+  .seasonal .s-img { width:20px; height:20px; flex:0 0 20px; border-radius:4px; box-shadow: 0 1px 3px rgba(0,0,0,.25); background: var(--surface); display:inline-flex; align-items:center; justify-content:center; overflow:hidden; }
+  .seasonal .s-img img { width:18px; height:18px; display:block; }
+  @keyframes pulse { 0% { transform: scale(1); } 50% { transform: scale(1.04); } 100% { transform: scale(1); } }
+  /* Tree row + marker hover link */
+  .tree-item--active { background: var(--surface); border-color: var(--nav-active-bg-end); box-shadow: 0 4px 12px rgba(0,0,0,.12); }
+  .leaflet-marker-icon.marker--dim { opacity: .5 !important; filter: saturate(.75) contrast(.95) !important; }
+  /* Marker halo (safe glow) */
+  /* Stronger, clearer halo for selected marker */
+  .leaflet-marker-icon.marker-halo {
+    filter:
+      drop-shadow(0 0 2px rgba(255,255,255,.9))
+      drop-shadow(0 0 8px rgba(85,139,110,.95))
+      drop-shadow(0 0 18px rgba(85,139,110,.55));
+  }
+  /* Marker wiggle without touching Leaflet's transform (kept but unused) */
+  @keyframes markerPop { 
+    0%   { width:24px; height:24px; margin-top:0; margin-left:0; filter: saturate(1); }
+    50%  { width:26px; height:26px; margin-top:-1px; margin-left:-1px; filter: saturate(1.15); }
+    100% { width:24px; height:24px; margin-top:0; margin-left:0; filter: saturate(1); }
+  }
+  .marker-waggle { animation: markerPop .55s ease; }
+  /* Breeze overlay when toggled */
+  .gs-container.breeze::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(180px 120px at 10% 20%, rgba(85,139,110,.10), rgba(85,139,110,0) 60%),
+                radial-gradient(160px 100px at 80% 70%, rgba(120,170,140,.09), rgba(120,170,140,0) 60%);
+    background-size: 140% 140%;
+    animation: breezeMove 16s linear infinite;
+    mix-blend-mode: screen;
+  }
+  @keyframes breezeMove {
+    0%   { background-position: 0% 0%, 100% 100%; }
+    50%  { background-position: 60% 40%, 40% 60%; }
+    100% { background-position: 0% 0%, 100% 100%; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .gs-container.breeze::before { animation: none; }
+  }
+  @media (min-width: 760px) {
+    .gs-meta { grid-template-columns: 1.2fr .8fr; align-items: start; }
+  }
   
 </style>
 {% endblock %}
@@ -33,23 +99,49 @@
   <div class="gs-header">
     <div>
       <h2 style="margin:0;color: var(--nav-active-bg-end);">{{ name }}</h2>
-      <small>Explore trees within this greenspace</small>
+      <small id="gs-desc-header">Loading description…</small>
     </div>
     <div class="gs-actions">
       <a class="subtle-link" data-haptic="soft" href="{{ url_for('pages.index') }}">← Back to Campus Map</a>
+      <button id="breeze-toggle" class="subtle-link" data-haptic="soft" aria-pressed="false" title="Ambient breeze">〰️ Breeze</button>
     </div>
   </div>
-  <div class="card"><div id="gs-map"></div></div>
+
+  <!-- Seasonal banner on top, above the map -->
+  <div class="card" id="gs-season-card" style="margin-bottom:12px;">
+    <div class="seasonal" id="gs-seasonal" aria-live="polite" aria-atomic="true" hidden>
+      <span class="s-img" aria-hidden="true"><img alt="" /></span>
+      <div>
+        <strong id="gs-season-title"></strong>
+        <div id="gs-season-text" style="opacity:.9"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card map-focus"><div id="gs-map"></div></div>
+  <div class="card" id="gs-info-card" style="margin-top:12px;">
+    <div class="gs-meta">
+      <div>
+        <h3 class="gs-section-title">Amenities</h3>
+        <div class="amenities" id="gs-amenities" aria-label="Amenities list"><em>Loading…</em></div>
+      </div>
+      <div>
+        <h3 class="gs-section-title">Good for</h3>
+        <div class="goodfor" id="gs-goodfor" aria-label="Recommended activities"><em>Loading…</em></div>
+      </div>
+    </div>
+  </div>
   <div class="tree-list card">
     <div class="list-head"><strong>Trees in this area</strong> <span id="tree-count"></span></div>
     <div id="tree-list" class="list"><em>Loading…</em></div>
   </div>
   <!-- Hidden data from server -->
-  <template id="gs-data" data-north="{{ bounds.north }}" data-south="{{ bounds.south }}" data-east="{{ bounds.east }}" data-west="{{ bounds.west }}"></template>
+  <template id="gs-data" data-north="{{ bounds.north }}" data-south="{{ bounds.south }}" data-east="{{ bounds.east }}" data-west="{{ bounds.west }}" data-name="{{ name }}" data-meta='{{ (gs_meta | tojson) if gs_meta else "" }}'></template>
 </div>
 {% endblock %}
 
 {% block extra_js %}
+<script src="{{ url_for('static', filename='js/greenspace.js') }}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     
@@ -72,6 +164,22 @@
 
     function iconUrlForTree(t){
       return window.treeIcons.getIconUrl(t.latin_name, t.common_name);
+    }
+
+    const nodeByTreeId = new Map();
+    function dimRest(activeMarker) {
+      try {
+        const icons = document.querySelectorAll('.leaflet-marker-icon');
+        icons.forEach(icon => {
+          if (activeMarker && activeMarker._icon === icon) icon.classList.remove('marker--dim');
+          else icon.classList.add('marker--dim');
+        });
+      } catch (_) {}
+    }
+    function clearDim() {
+      try { document.querySelectorAll('.leaflet-marker-icon.marker--dim').forEach(i => i.classList.remove('marker--dim')); } catch(_) {}
+    }
+    function softHaptic(){ try { if (navigator.vibrate) navigator.vibrate(3); } catch(_) {}
     }
 
     function renderTrees(trees) {
@@ -98,6 +206,20 @@
         m.on('pointerdown', (e) => { try { window.cgAudio && window.cgAudio.play('explore'); } catch(err) {} try { e.originalEvent && e.originalEvent.stopPropagation && e.originalEvent.stopPropagation(); } catch(_) {} });
         m.on('mousedown', (e) => { try { window.cgAudio && window.cgAudio.play('explore'); } catch(err) {} try { e.originalEvent.stopPropagation(); } catch(_) {} });
         m.on('touchstart', (e) => { try { window.cgAudio && window.cgAudio.play('explore'); } catch(err) {} try { e.originalEvent.stopPropagation(); } catch(_) {} });
+        // Hover highlight link: marker <-> list row
+        // On marker hover: add halo and highlight the corresponding row
+        m.on('mouseover', () => {
+          try { if (m._icon) { m._icon.classList.add('marker-halo'); } } catch(_) {}
+          dimRest(m); softHaptic();
+          const pair = nodeByTreeId.get(t.tree_id);
+          if (pair && pair.row) pair.row.classList.add('tree-item--active');
+        });
+        m.on('mouseout', () => {
+          try { if (m._icon) { m._icon.classList.remove('marker-halo'); } } catch(_) {}
+          clearDim();
+          const pair = nodeByTreeId.get(t.tree_id);
+          if (pair && pair.row) pair.row.classList.remove('tree-item--active');
+        });
         m.on('click', (e) => {
           try { if (m._icon) { m._icon.classList.remove('tree-pulse'); void m._icon.offsetWidth; m._icon.classList.add('tree-pulse'); } } catch(_) {}
           navigateWithSound(`/tree/${t.tree_id}?return_to=${returnTo}`);
@@ -113,6 +235,17 @@
           </div>
           <div class="ti-arrow">›</div>
         `;
+        nodeByTreeId.set(t.tree_id, { marker: m, row });
+        row.addEventListener('mouseenter', () => {
+          row.classList.add('tree-item--active');
+          try { if (m._icon) { m._icon.classList.add('marker-halo'); } } catch(_) {}
+          dimRest(m); softHaptic();
+        });
+        row.addEventListener('mouseleave', () => {
+          row.classList.remove('tree-item--active');
+          try { if (m._icon) { m._icon.classList.remove('marker-halo'); } } catch(_) {}
+          clearDim();
+        });
         row.addEventListener('pointerdown', () => {
           try { window.cgAudio && window.cgAudio.play('explore'); } catch(e) {}
           try { const img = row.querySelector('.ti-icon img'); if (img) { img.classList.remove('tree-pulse'); void img.offsetWidth; img.classList.add('tree-pulse'); } } catch(_) {}
@@ -132,6 +265,7 @@
       .then(data => {
         if (Array.isArray(data)) {
           renderTrees(data);
+          try { if (window.gsSeasonal && typeof window.gsSeasonal.update === 'function') { window.gsSeasonal.update(data, t.dataset.name || '{{ name }}'); } } catch(e) { console.debug('seasonal update failed', e); }
         } else {
           console.error('Unexpected response shape for trees/area', data);
           list.innerHTML = '<em>Unable to load trees for this area.</em>';


### PR DESCRIPTION
 Clear greenspace UX meta
 
 - What’s changed
      - Header: Sticky card with title + one-line description.
      - Seasonal: Banner above map rotates real trees in bounds with tiny icon
  + fact.
      - Info under map: “Amenities” (emoji badges) and “Good for” chips.
      - Interactions: Hover row/marker → active marker halo; others dim to 50%;
  light haptics.
      - Visuals: Subtle map focus “breathing” frame; optional ambient “Breeze”
  overlay + quiet rustling loop.

      - No dependencies added; pure CSS/JS; emoji-based icons.


  - How to test
      - Open a greenspace: header shows description; seasonal banner appears above
  map.
      - Hover list rows or markers: halo on active marker, others dim; unhover
  clears.
      - Toggle Breeze: see soft moving gradient; hear very quiet rustling; tab
  hide pauses audio.
      - Confirm seasonal rotates entries ~every 8s and uses trees in this area.
  - Future follow-ups (optional)
